### PR TITLE
Added Shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Community Extension](https://img.shields.io/badge/Community%20Extension-An%20open%20source%20community%20maintained%20project-FF4700) 
+![Lifecycle](https://img.shields.io/badge/Lifecycle-Incubating-blue)
+
 # Camunda Cloud Kubernetes Zeebe Operator
 
 This repository contains the source code for the Zeebe Operator for Camunda Cloud. 


### PR DESCRIPTION
Added Shields.io badges to indicate that this is a community maintained extension and that it is in the [incubating](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md) lifecycle stage.